### PR TITLE
Add go.mod, fix formatting, fix license link

### DIFF
--- a/bt_tree.go
+++ b/bt_tree.go
@@ -1,7 +1,7 @@
-// MIT License: See https://github.com/pzsz/voronoi/LICENSE.md
+// MIT License: See https://github.com/pzsz/voronoi/blob/master/LICENSE.md
 
 // Author: Przemyslaw Szczepaniak (przeszczep@gmail.com)
-// Port of Raymond Hill's (rhill@raymondhill.net) javascript implementation 
+// Port of Raymond Hill's (rhill@raymondhill.net) javascript implementation
 // of Steven  Forune's algorithm to compute Voronoi diagrams
 
 package voronoi

--- a/cell.go
+++ b/cell.go
@@ -1,8 +1,8 @@
 // Copyright 2013 Przemyslaw Szczepaniak.
-// MIT License: See https://github.com/gorhill/Javascript-Voronoi/LICENSE.md
+// MIT License: See https://github.com/pzsz/voronoi/blob/master/LICENSE.md
 
 // Author: Przemyslaw Szczepaniak (przeszczep@gmail.com)
-// Port of Raymond Hill's (rhill@raymondhill.net) javascript implementation 
+// Port of Raymond Hill's (rhill@raymondhill.net) javascript implementation
 // of Steven  Forune's algorithm to compute Voronoi diagrams
 
 package voronoi

--- a/geometry.go
+++ b/geometry.go
@@ -1,7 +1,7 @@
-// MIT License: See https://github.com/pzsz/voronoi/LICENSE.md
+// MIT License: See https://github.com/pzsz/voronoi/blob/master/LICENSE.md
 
 // Author: Przemyslaw Szczepaniak (przeszczep@gmail.com)
-// Port of Raymond Hill's (rhill@raymondhill.net) javascript implementation 
+// Port of Raymond Hill's (rhill@raymondhill.net) javascript implementation
 // of Steven Forune's algorithm to compute Voronoi diagrams
 
 package voronoi

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pzsz/voronoi
+
+go 1.23.0

--- a/utils/cell.go
+++ b/utils/cell.go
@@ -1,9 +1,8 @@
 // Copyright 2013 Przemyslaw Szczepaniak.
-// MIT License: See https://github.com/gorhill/Javascript-Voronoi/LICENSE.md
+// MIT License: See https://github.com/pzsz/voronoi/blob/master/LICENSE.md
 
 // Author: Przemyslaw Szczepaniak (przeszczep@gmail.com)
 // Utils for processing voronoi diagrams
-
 
 package utils
 
@@ -21,7 +20,7 @@ func CellArea(cell *voronoi.Cell) float64 {
 		area -= s.Y * e.X
 	}
 
-	return area/2
+	return area / 2
 }
 
 // Calculate centroid of a cell
@@ -31,13 +30,12 @@ func CellCentroid(cell *voronoi.Cell) voronoi.Vertex {
 		s := halfedge.GetStartpoint()
 		e := halfedge.GetEndpoint()
 		v := s.X*e.Y - e.X*s.Y
-		x += (s.X+e.X) * v
-		y += (s.Y+e.Y) * v
+		x += (s.X + e.X) * v
+		y += (s.Y + e.Y) * v
 	}
 	v := CellArea(cell) * 6
-	return voronoi.Vertex{x/v, y/v}
+	return voronoi.Vertex{x / v, y / v}
 }
-
 
 // Calculate centroid of a cell
 func InsideCell(cell *voronoi.Cell, v voronoi.Vertex) bool {
@@ -45,7 +43,7 @@ func InsideCell(cell *voronoi.Cell, v voronoi.Vertex) bool {
 		a := halfedge.GetStartpoint()
 		b := halfedge.GetEndpoint()
 
-		cross := ((b.X - a.X)*(v.Y - a.Y) - (b.Y - a.Y)*(v.X - a.X))
+		cross := ((b.X-a.X)*(v.Y-a.Y) - (b.Y-a.Y)*(v.X-a.X))
 
 		if cross > 0 {
 			return false
@@ -59,6 +57,6 @@ func EdgeIndex(cell *voronoi.Cell, edge *voronoi.Edge) int {
 		if halfedge.Edge == edge {
 			return i
 		}
-	}	
+	}
 	return -1
 }

--- a/utils/relaxation.go
+++ b/utils/relaxation.go
@@ -1,5 +1,5 @@
 // Copyright 2013 Przemyslaw Szczepaniak.
-// MIT License: See https://github.com/gorhill/Javascript-Voronoi/LICENSE.md
+// MIT License: See https://github.com/pzsz/voronoi/blob/master/LICENSE.md
 
 // Author: Przemyslaw Szczepaniak (przeszczep@gmail.com)
 // Utils for processing voronoi diagrams
@@ -9,7 +9,6 @@ package utils
 import (
 	"github.com/pzsz/voronoi"
 )
-
 
 // Apply lloyd relaxation algorithm to the cells.
 func LloydRelaxation(cells []*voronoi.Cell) (ret []voronoi.Vertex) {

--- a/utils/sites.go
+++ b/utils/sites.go
@@ -1,5 +1,5 @@
 // Copyright 2013 Przemyslaw Szczepaniak.
-// MIT License: See https://github.com/gorhill/Javascript-Voronoi/LICENSE.md
+// MIT License: See https://github.com/pzsz/voronoi/blob/master/LICENSE.md
 
 // Author: Przemyslaw Szczepaniak (przeszczep@gmail.com)
 // Utils for processing voronoi diagrams
@@ -7,8 +7,9 @@
 package utils
 
 import (
-	"github.com/pzsz/voronoi"
 	"math/rand"
+
+	"github.com/pzsz/voronoi"
 )
 
 // Generate random sites in given bounding box
@@ -17,8 +18,8 @@ func RandomSites(bbox voronoi.BBox, count int) []voronoi.Vertex {
 	w := bbox.Xr - bbox.Xl
 	h := bbox.Yb - bbox.Yt
 	for j := 0; j < count; j++ {
-		sites[j].X = rand.Float64() * w + bbox.Xl
-		sites[j].Y = rand.Float64() * h + bbox.Yt
+		sites[j].X = rand.Float64()*w + bbox.Xl
+		sites[j].Y = rand.Float64()*h + bbox.Yt
 	}
 	return sites
 }

--- a/utils/vertex.go
+++ b/utils/vertex.go
@@ -1,5 +1,5 @@
 // Copyright 2013 Przemyslaw Szczepaniak.
-// MIT License: See https://github.com/gorhill/Javascript-Voronoi/LICENSE.md
+// MIT License: See https://github.com/pzsz/voronoi/blob/master/LICENSE.md
 
 // Author: Przemyslaw Szczepaniak (przeszczep@gmail.com)
 // Utils for processing voronoi diagrams
@@ -8,11 +8,12 @@ package utils
 
 import (
 	"math"
+
 	"github.com/pzsz/voronoi"
 )
 
-func Distance(a,b voronoi.Vertex) float64 {
+func Distance(a, b voronoi.Vertex) float64 {
 	dx := a.X - b.X
 	dy := a.Y - b.Y
-	return math.Sqrt(dx*dx+dy*dy)
+	return math.Sqrt(dx*dx + dy*dy)
 }

--- a/voronoi.go
+++ b/voronoi.go
@@ -1,7 +1,7 @@
-// MIT License: See https://github.com/pzsz/voronoi/LICENSE.md
+// MIT License: See https://github.com/pzsz/voronoi/blob/master/LICENSE.md
 
 // Author: Przemyslaw Szczepaniak (przeszczep@gmail.com)
-// Port of Raymond Hill's (rhill@raymondhill.net) javascript implementation 
+// Port of Raymond Hill's (rhill@raymondhill.net) javascript implementation
 // of Steven Forune's algorithm to compute Voronoi diagrams
 
 package voronoi
@@ -515,7 +515,7 @@ func (s *Voronoi) attachCircleEvent(arc *Beachsection) {
 	// Important: ybottom should always be under or at sweep, so no need
 	// to waste CPU cycles by checking
 
-	// recycle circle event object if possible	
+	// recycle circle event object if possible
 	circleEventInst := &circleEvent{
 		arc:     arc,
 		site:    cSite,
@@ -582,8 +582,9 @@ func NewBBox(xl, xr, yt, yb float64) BBox {
 // connect dangling edges (not if a cursory test tells us
 // it is not going to be visible.
 // return value:
-//   false: the dangling endpoint couldn't be connected
-//   true: the dangling endpoint could be connected
+//
+//	false: the dangling endpoint couldn't be connected
+//	true: the dangling endpoint could be connected
 func connectEdge(edge *Edge, bbox BBox) bool {
 	// skip if end point already connected
 	vb := edge.Vb.Vertex
@@ -696,8 +697,10 @@ func connectEdge(edge *Edge, bbox BBox) bool {
 }
 
 // line-clipping code taken from:
-//   Liang-Barsky function by Daniel White
-//   http://www.skytopia.com/project/articles/compsci/clipping.html
+//
+//	Liang-Barsky function by Daniel White
+//	http://www.skytopia.com/project/articles/compsci/clipping.html
+//
 // Thanks!
 // A bit modified to minimize code paths
 func clipEdge(edge *Edge, bbox BBox) bool {
@@ -768,7 +771,7 @@ func clipEdge(edge *Edge, bbox BBox) bool {
 			t0 = r
 		}
 	}
-	// bottom        
+	// bottom
 	q = bbox.Yb - ay
 	if dy == 0 && q < 0 {
 		return false
@@ -951,7 +954,7 @@ func (s *Voronoi) gatherVertexEdges() {
 	}
 }
 
-// Compute voronoi diagram. If closeCells == true, edges from bounding box will be 
+// Compute voronoi diagram. If closeCells == true, edges from bounding box will be
 // included in diagram.
 func ComputeDiagram(sites []Vertex, bbox BBox, closeCells bool) *Diagram {
 	s := &Voronoi{

--- a/voronoi_test.go
+++ b/voronoi_test.go
@@ -1,15 +1,16 @@
 // MIT License: See https://github.com/pzsz/voronoi/LICENSE.md
 
 // Author: Przemyslaw Szczepaniak (przeszczep@gmail.com)
-// Port of Raymond Hill's (rhill@raymondhill.net) javascript implementation 
+// Port of Raymond Hill's (rhill@raymondhill.net) javascript implementation
 // of Steven Forune's algorithm to compute Voronoi diagrams
 
 package voronoi_test
 
 import (
-	. "github.com/pzsz/voronoi"
 	"math/rand"
 	"testing"
+
+	. "github.com/pzsz/voronoi"
 )
 
 func verifyDiagram(diagram *Diagram, edgesCount, cellsCount, perCellCount int, t *testing.T) {


### PR DESCRIPTION
- add go.mod as now-standard way of package management for Go
- run `go fmt ./...` and fix formatting to standard
- fix broken link to `LICENSE.md` file (license itself unchanged)
